### PR TITLE
Fix render_engine.themes import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,8 @@ readme = "README.md"
 
 dependencies = [
     'jinja2',
-    'render-engine-tailwindcss==2023.10.2',
-    "render-engine>=2023.11.1a3"
+    'render-engine-tailwindcss>=2023.12.1',
+    "render-engine>=2023.12.1b1"
     ]
 
 [project.optional-dependencies]

--- a/src/render_engine_theme_kjaymiller/kjaymiller.py
+++ b/src/render_engine_theme_kjaymiller/kjaymiller.py
@@ -1,7 +1,7 @@
 import pathlib
 
 from jinja2 import PackageLoader
-from render_engine.utils.themes import Theme
+from render_engine.themes import Theme
 from render_engine_tailwindcss import TailwindCSS
 
 from .tailwind_colors import (


### PR DESCRIPTION
This pull request fixes the import statement for the `Theme` class in the `render_engine.themes` module. 

This is in sync with guidance from https://github.com/render-engine/render-engine/discussions/430#discussioncomment-7736279