### PR TITLE
🛠️ typo in render_engine command

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -e .
-          python -m render-engine build docs.app:app
+          python -m render_engine build docs.app:app
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -40,6 +40,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -e .
           python -m render_engine build docs.app:app
+          
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
This pull request fixes a typo in the `render_engine` command in the static.yml file. The command was previously written as `render-engine` instead of `render_engine`. This typo caused the build process to fail. 